### PR TITLE
Bug fixes 20170522

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <uk.ac.ebi.pride.jaxb-pride-jaxb.version>1.0.18</uk.ac.ebi.pride.jaxb-pride-jaxb.version>
         <uk.ac.ebi.pride.utilities-pride-utilities.version>2.0.14</uk.ac.ebi.pride.utilities-pride-utilities.version>
         <uk.ac.ebi.pride.toolsuite-inspector-swing-utils.version>2.0.3</uk.ac.ebi.pride.toolsuite-inspector-swing-utils.version>
-        <uk.ac.ebi.pride-px-submission-core.version>2.0.15</uk.ac.ebi.pride-px-submission-core.version>
+        <uk.ac.ebi.pride-px-submission-core.version>2.0.16-SNAPSHOT</uk.ac.ebi.pride-px-submission-core.version>
         <uk.ac.ebi.pride.px-libpxreport.version>1.1</uk.ac.ebi.pride.px-libpxreport.version>
         <uk.ac.ebi.pride.toolsuite-ols-dialog.version>3.4.9</uk.ac.ebi.pride.toolsuite-ols-dialog.version>
         <uk.ac.ebi.jmzidml-jmzidentml.version>1.2.6</uk.ac.ebi.jmzidml-jmzidentml.version>

--- a/src/main/java/uk/ac/ebi/pride/gui/form/panel/PrideLoginPanel.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/form/panel/PrideLoginPanel.java
@@ -100,8 +100,8 @@ public class PrideLoginPanel extends ContextAwareHeaderPanel {
             warningBalloonTip.closeBalloon();
         }
 
-        // user name
-        if (SubmissionValidator.validateName(userNameField.getText()).hasError()) {
+        // validate username
+        if (SubmissionValidator.validateUserName(userNameField.getText()).hasError()) {
             if (showWarning) {
                 warningBalloonTip = BalloonTipUtil.createErrorBalloonTip(userNameField, appContext.getProperty("pride.login.username.error.message"));
                 warningBalloonTip.setVisible(true);

--- a/src/main/java/uk/ac/ebi/pride/gui/util/ColourUtil.java
+++ b/src/main/java/uk/ac/ebi/pride/gui/util/ColourUtil.java
@@ -15,7 +15,7 @@ public final class ColourUtil {
     public static final Color ALTER_ROW_COLOUR = new Color(229, 232, 236);
     public static final Color ROW_SELECTION_BACKGROUND = new Color(193, 210, 238);
     public static final Color ROW_SELECTION_FOREGROUND = Color.black;
-    public static final Color TEXT_FIELD_WARNING_COLOUR = new Color(255, 255, 153);
+    public static final Color TEXT_FIELD_WARNING_COLOUR = new Color(255, 190, 188);
     public static final Color TEXT_FIELD_NORMAL_COLOUR = Color.white;
     public static final Color HYPERLINK_COLOUR = new Color(98, 146, 179);
 

--- a/src/main/resources/prop/gui.prop
+++ b/src/main/resources/prop/gui.prop
@@ -147,7 +147,7 @@ lab.head.email.tooltip = Email address of the lab head
 lab.head.email.error.message = Email address must be valid
 lab.head.affiliation.hint = Lab head's affiliation, such as: department, lab, institute and country
 lab.head.affiliation.tooltip = Affiliation of the lab head
-lab.head.affiliation.error.message = Affiliation cannot be empty
+lab.head.affiliation.error.message = Affiliation cannot be empty, and must be <500 characters long.
 
 
 # sample metadata labels and icons


### PR DESCRIPTION
- User login should validate the 'username' not 'name' of the submitter.
- Added advice on the limits for lab head affiliation.
- New px-submission-core snapshot version to improve 'name' and 'affiliation' validation: a name requires at least a first and last name separated by a space, and affiliation needs to be up to 500 characters long (not longer). If OK, the px-submission-core artefact will need to be released to a non-snapshot version, and then updated in the submission tool.
- Updated error background colour to red instead of yellow. I think this highlights what text field is wrong instead of yellow, what do you think? If this change isn't needed please feel free to remove it.